### PR TITLE
Users/jagamu/wi changes for k8s

### DIFF
--- a/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
+++ b/tools/scripts/AksEdgeQuickStart/AksEdgeQuickStartForAio.ps1
@@ -81,7 +81,7 @@ param(
     [string] $subscriptionId
 )
 
-    $retries = 20
+    $retries = 60
     for (; $retries -gt 0; $retries--)
     {
         $connectedCluster = az connectedk8s show -g $resourceGroup -n $clusterName --subscription $subscriptionId | ConvertFrom-Json


### PR DESCRIPTION
Enable WI for k8s for AIO

Currently "AksEdgeProductUrl" is set by default "C:\\Users\\Public\\msi\\K3s.msi". This should be replace with path for k8s msi or leave it blank. The latest published k8s.msi will be downloaded.
Note: 1.6.384 k8s.msi will work - it does not need any chnages to config unlike k3s.